### PR TITLE
Fix some boolean operators in promote scripts

### DIFF
--- a/scripts/promote-beta-experimental-opt-in.ts
+++ b/scripts/promote-beta-experimental-opt-in.ts
@@ -14,7 +14,7 @@ const {amp_version: AMP_VERSION}: Args = minimist(process.argv.slice(2));
 
 void runPromoteJob(jobName, async () => {
   await createVersionsUpdatePullRequest((currentVersions) => {
-    const ampVersion = AMP_VERSION ?? currentVersions.nightly.slice(2);
+    const ampVersion = AMP_VERSION || currentVersions.nightly.slice(2);
 
     return {
       versionsChanges: {

--- a/scripts/promote-beta-experimental-traffic.ts
+++ b/scripts/promote-beta-experimental-traffic.ts
@@ -48,13 +48,13 @@ async function fetchActiveExperiments(
 }
 
 function maybeRtv(experiment: ExperimentConfig, rtv: string): string | null {
-  return experiment.define_experiment_constant ?? rtv;
+  return experiment.define_experiment_constant ? rtv : null;
 }
 
 void runPromoteJob(jobName, async () => {
   await createVersionsUpdatePullRequest(async (currentVersions) => {
     // We assume that the AMP version number is the same for beta-opt-in and experimental-opt-in, and only differ in their RTV prefix.
-    const ampVersion = AMP_VERSION ?? currentVersions['beta-opt-in'].slice(2);
+    const ampVersion = AMP_VERSION || currentVersions['beta-opt-in'].slice(2);
 
     const activeExperiments = await fetchActiveExperiments(ampVersion);
 

--- a/scripts/promote-lts.ts
+++ b/scripts/promote-lts.ts
@@ -24,7 +24,7 @@ void runPromoteJob(jobName, async () => {
   }
 
   await createVersionsUpdatePullRequest((currentVersions) => {
-    const ampVersion = AMP_VERSION ?? currentVersions.stable.slice(2);
+    const ampVersion = AMP_VERSION || currentVersions.stable.slice(2);
 
     return {
       versionsChanges: {

--- a/scripts/promote-stable.ts
+++ b/scripts/promote-stable.ts
@@ -15,7 +15,7 @@ const {amp_version: AMP_VERSION}: Args = minimist(process.argv.slice(2));
 void runPromoteJob(jobName, async () => {
   await createVersionsUpdatePullRequest((currentVersions) => {
     // We assume that the AMP version number is the same for beta-traffic and experimental-traffic, and only differ in their RTV prefix.
-    const ampVersion = AMP_VERSION ?? currentVersions['beta-traffic'].slice(2);
+    const ampVersion = AMP_VERSION || currentVersions['beta-traffic'].slice(2);
 
     return {
       versionsChanges: {


### PR DESCRIPTION
Nullish coalescing was the wrong operator to use, since `minimist` returns an empty string for empty flags