### PR TITLE
Add an empty line between channels in versions.json to prevent merge conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check configs
         run: npx ts-mocha ./test/check-json-schemas.ts
 
+      - name: Check versions.json whitespace
+        run: npx ts-mocha ./test/check-versions-whitespace.ts
+
       - name: Check file changes
         run: npx ts-mocha ./test/check-file-changes.ts --diff="${{ steps.get-diff.outputs.diff }}"
 

--- a/configs/versions.json
+++ b/configs/versions.json
@@ -1,14 +1,25 @@
 {
   "beta-opt-in": "032201212122000",
+
   "beta-traffic": "032201141909000",
+
   "control": "022201122239000",
+
   "experimental-opt-in": "002201212122000",
+
   "experimental-traffic": "002201141909000",
+
   "experimentA": null,
+
   "experimentB": null,
+
   "experimentC": null,
+
   "lts": "012201122239000",
+
   "nightly": "042201252222000",
+
   "nightly-control": "052201122239000",
+
   "stable": "012201122239000"
 }

--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -77,6 +77,12 @@ export async function createVersionsUpdatePullRequest(
     ...versionsChanges,
   };
 
+  // Ensure that there is an empty line between each channel, so that multiple
+  // auto-generated PRs that modify different channels will not result in a
+  // merge conflict.
+  const newVersionsJsonString =
+    JSON.stringify(newVersions, undefined, 2).replace(/,\n/g, ',\n\n') + '\n';
+
   const pullRequestResponse = await octokit.createPullRequest({
     ...params,
     title,
@@ -85,7 +91,7 @@ export async function createVersionsUpdatePullRequest(
     changes: [
       {
         files: {
-          [versionsJsonFile]: JSON.stringify(newVersions, undefined, 2) + '\n',
+          [versionsJsonFile]: newVersionsJsonString,
         },
         commit: title,
       },

--- a/test/check-versions-whitespace.ts
+++ b/test/check-versions-whitespace.ts
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+
+const versionsFilePath = path.join(__dirname, '../configs/versions.json');
+
+describe('check versions.json whitespace', () => {
+  it('whitespace exists', () => {
+    const versionsJsonString = fs.readFileSync(versionsFilePath, 'utf-8');
+
+    const expectedVersionsJsonString =
+      JSON.stringify(JSON.parse(versionsJsonString), undefined, 2).replace(
+        /,\n/g,
+        ',\n\n'
+      ) + '\n';
+
+    assert.equal(versionsJsonString, expectedVersionsJsonString);
+  });
+});

--- a/test/check-versions-whitespace.ts
+++ b/test/check-versions-whitespace.ts
@@ -14,6 +14,10 @@ describe('check versions.json whitespace', () => {
         ',\n\n'
       ) + '\n';
 
-    assert.equal(versionsJsonString, expectedVersionsJsonString);
+    assert.equal(
+      versionsJsonString,
+      expectedVersionsJsonString,
+      'The format of versions.json is incorrect, see resulting diff for expected format. The format is strictly enforced to prevent Git merge conflicts in multiple parallel auto-generated PRs that modify disparate channels.'
+    );
   });
 });

--- a/test/check-versions-whitespace.ts
+++ b/test/check-versions-whitespace.ts
@@ -17,7 +17,7 @@ describe('check versions.json whitespace', () => {
     assert.equal(
       versionsJsonString,
       expectedVersionsJsonString,
-      'The format of versions.json is incorrect, see resulting diff for expected format. The format is strictly enforced to prevent Git merge conflicts in multiple parallel auto-generated PRs that modify disparate channels.'
+      'The format of versions.json is incorrect, there must be an empty line between each channel name. This format is enforced to prevent Git merge conflicts in automated PRs.'
     );
   });
 });


### PR DESCRIPTION
Multiple auto-generated promote-PRs can cause a merge conflict even when they modify different lines, as the Git merge algorithm can't guarantee that these are indeed disparate lines and not related to each other.

A ridiculous but simple solution is to enforce an empty line between each channel.

This PR adds these empty lines, and a CI test to verify that the file is formatted as expected

Example error message when some empty lines are missing:
![image](https://user-images.githubusercontent.com/1839738/151064358-af528f4f-970b-4d3e-b4a9-58274ad8d537.png)