### PR TITLE
Manually sync versions.json with cdn.ampproject.org's current value

### DIFF
--- a/configs/versions.json
+++ b/configs/versions.json
@@ -1,13 +1,13 @@
 {
-  "beta-opt-in": "032201262038000",
+  "beta-opt-in": "032201262038001",
 
-  "beta-traffic": "032201212122002",
+  "beta-traffic": "032201212122003",
 
-  "control": "022201141909003",
+  "control": "022201212122003",
 
-  "experimental-opt-in": "002201262038000",
+  "experimental-opt-in": "002201262038001",
 
-  "experimental-traffic": "002201212122002",
+  "experimental-traffic": "002201212122003",
 
   "experimentA": null,
 
@@ -19,7 +19,7 @@
 
   "nightly": "042201262038000",
 
-  "nightly-control": "052201141909003",
+  "nightly-control": "052201212122003",
 
-  "stable": "012201141909003"
+  "stable": "012201212122003"
 }


### PR DESCRIPTION
Since I had to perform some of the release actions directly on the Google CDN (due to some sync issues that, hopefully, are fixed now) I'm creating this PR manually to sync those updates to this repo. I'll continue the rest of the release-on-duty tasks after I merge this PR

If all goes well the CDN should say this PR failed to deploy - a side-effect of it not making any changes on the Google CDN (it's an edge case I haven't handled yet)