### PR TITLE
Perform parallel cherry-picks for multiple AMP versions

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -35,6 +35,12 @@ jobs:
     environment: cherry-pick
 
     strategy:
+      # Do not fail other cherry-picks just because another one fails. It is
+      # possible that only one cherry-pick out of many will fail because of a
+      # merge conflict that doesn't exist in the other release branches. The
+      # release-on-duty should investigate and fix the failed CPs manually.
+      fail-fast: false
+
       matrix:
         amp-version: ${{ fromJSON(needs.generate-matrix.outputs.amp-versions) }}
 

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -3,20 +3,40 @@ name: Cherry-pick a release
 on:
   workflow_dispatch:
     inputs:
-      amp-version:
-        description: AMP version (13 digits)
+      amp-versions:
+        description: AMP version(s) (13 digits) to cherry-pick onto. Perform multiple parallel cherry-picks with a space delimited list (e.g., 2111242025001 2202022130000)
         required: true
         type: string
       shas:
-        description: commit sha(s) to cherry-pick with (i.e. abcdef1 abcdef2)
+        description: commit sha(s) to cherry-pick with. Stack multiple commits together with a space delimited list (e.g., abcdef1 abcdef2)
         required: true
         type: string
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      amp-versions: ${{ steps.generate-matrix.outputs.amp-versions }}
+
+    steps:
+      - name: ⭐ Generate Matrix ⭐
+        id: generate-matrix
+        run: |
+          read -r -a AMP_VERSIONS <<< "${{ github.event.inputs.amp-versions }}"
+          AMP_VERSIONS=$(jq --compact-output --null-input '$ARGS.positional' --args ${AMP_VERSIONS[@]})
+          echo ::set-output name=amp-versions::${AMP_VERSIONS}
+
   cherry-pick:
+    needs: generate-matrix
+
     runs-on: ubuntu-latest
 
     environment: cherry-pick
+
+    strategy:
+      matrix:
+        amp-version: ${{ fromJSON(needs.generate-matrix.outputs.amp-versions) }}
 
     steps:
       - name: Checkout ampproject/amphtml
@@ -26,11 +46,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.ACCESS_TOKEN }}
 
-      - name: Generate cherry-pick branch name
+      - name: Generate cherry-pick branch name for ${{ matrix.amp-version }}
         id: get-branch
         run: |
           # get amp version to be cherry-picked
-          AMP_VERSION=${{ github.event.inputs.amp-version }}
+          AMP_VERSION=${{ matrix.amp-version }}
 
           # get number of commits to cherry-pick
           read -r -a SHAS_ARRAY <<< "${{ github.event.inputs.shas }}"
@@ -56,9 +76,9 @@ jobs:
           git config --global user.name $NAME
           git config --global user.email $EMAIL
 
-      - name: Cherry-pick ${{ github.event.inputs.amp-version }} with ${{ github.event.inputs.shas }}
+      - name: ⭐ Cherry-pick ${{ matrix.amp-version }} with ${{ github.event.inputs.shas }} ⭐
         run: |
-          git checkout -b ${{ steps.get-branch.outputs.branch }} ${{ github.event.inputs.amp-version }}
+          git checkout -b ${{ steps.get-branch.outputs.branch }} ${{ matrix.amp-version }}
           git cherry-pick -x ${{ github.event.inputs.shas }}
           git push --set-upstream https://github.com/ampproject/amphtml.git ${{ steps.get-branch.outputs.branch }}
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ For more information about schedules and channels, see https://github.com/amppro
 
 ## Cherry-picking a release
 
-To cherry-pick a release, run the [`Cherry-pick a release`](https://github.com/ampproject/cdn-configuration/actions/workflows/cherry-pick.yml) workflow. It asks for the AMP version to fix, as well as the commit shas to cherry-pick. For multiple commits, separate the shas with a space.
+To cherry-pick a release, run the [`Cherry-pick a release`](https://github.com/ampproject/cdn-configuration/actions/workflows/cherry-pick.yml) workflow. It asks for one or more AMP versions to fix, as well as the commit shas to cherry-pick. For multiple AMP versions and/or commits shas, separate the shas with a space.
+
+> _Each_ of the listed AMP version will cherry-picked with _all_ of the listed commit shas. e.g., by listing AMP versions `2111242025001 2202022130000` and commit shas `abcdef1 abcdef2`, the workflow will:
+>
+> - Cherry pick `abcdef1` on top of `2111242025001`, then `abcdef2` on top of the result, and
+> - Cherry pick `abcdef1` on top of `2202022130000`, then `abcdef2` on top of the result
 
 How it works: the workflow pushes a new branch to amphtml. CircleCI will pick up that branch and build the release. Once built and uploaded to [`ampjs.org`](https://ampjs.org), the CircleCI job will trigger the promote workflow.
 


### PR DESCRIPTION
I had to perform a CP on 3 releases this week, all for the same fix (`stable`, `{beta,experimental}-opt-in`, and , `{beta,experimental}-traffic`), it felt like something that should be easily parallelized

![image](https://user-images.githubusercontent.com/1839738/152426844-dfb6a7a8-060a-47d6-b37a-461c4c724076.png)

![image](https://user-images.githubusercontent.com/1839738/152426892-c1de2f36-451a-4554-b87c-dfbc88d1a3f7.png)
(failure is because I tried it on my own fork without giving the workflow write access; the point that fails hasn't changed so I _think_ it's safe to assume it wouldn't break just because we replaced the variable source)