### PR TITLE
List the cherry-picked PRs in the generated PR that promotes an cherry-picked AMP version

### DIFF
--- a/scripts/promote-cherry-picks.ts
+++ b/scripts/promote-cherry-picks.ts
@@ -85,7 +85,7 @@ function generateBody(
       )
       .join('\n');
   }
-  body += `\n\n[Release branch commits](https://github.com/ampproject/amphtml/commits/amp-release-${ampVersion})`;
+  body += `\n\nCommits on release branch: [amp-release-${ampVersion}](https://github.com/ampproject/amphtml/commits/amp-release-${ampVersion})`;
   return body;
 }
 

--- a/scripts/promote-cherry-picks.ts
+++ b/scripts/promote-cherry-picks.ts
@@ -4,7 +4,11 @@
 
 import yargs from 'yargs/yargs';
 import {Prefixes, Versions} from '../configs/schemas/versions';
-import {createVersionsUpdatePullRequest, runPromoteJob} from './promote-job';
+import {
+  createVersionsUpdatePullRequest,
+  octokit,
+  runPromoteJob,
+} from './promote-job';
 import {getChannels} from './get-channels-utils';
 
 interface Args {
@@ -19,6 +23,10 @@ const {amp_version: ampVersion}: Args = yargs(process.argv.slice(2))
 const jobName = 'promote-cherry-pick.ts';
 const ampVersionWithoutCherryPicksCounter = ampVersion.slice(0, 10);
 const cherryPicksCount = ampVersion.slice(-3);
+
+function defined<T>(value: T): value is NonNullable<T> {
+  return value !== undefined;
+}
 
 function getAmpVersionToCherrypick(
   ampVersion: string,
@@ -37,8 +45,51 @@ function getAmpVersionToCherrypick(
   return ampVersionToCherrypick.slice(-13);
 }
 
+async function getCherryPickedPRs(
+  ampVersion: string,
+  numberOfCherryPickedCommits: number
+): Promise<string[]> {
+  try {
+    const {data} = await octokit.rest.repos.listCommits({
+      owner: 'ampproject',
+      repo: 'amphtml',
+      sha: ampVersion,
+      per_page: numberOfCherryPickedCommits,
+    });
+    return data
+      .map(({commit}) => {
+        const [firstLine] = commit.message.split('\n');
+        const matches = firstLine?.match(/\(#(?<pullNumber>\d+)\)$/);
+        return matches?.groups?.pullNumber;
+      })
+      .filter(defined);
+  } catch (err) {
+    console.warn('Could not fetch the list of cherry picked PRs, skipping...');
+    console.warn('Exception thrown:', err);
+    return [];
+  }
+}
+
+function generateBody(
+  ampVersion: string,
+  channels: string,
+  cherryPickedPRs: string[]
+): string {
+  let body = `Promoting release ${ampVersion} to channels: ${channels}`;
+  if (cherryPickedPRs.length) {
+    body += '\n\nPRs included in this cherry pick:\n';
+    body += cherryPickedPRs
+      .map(
+        (pullNumber) =>
+          `* https://github.com/ampproject/amphtml/pull/${pullNumber}`
+      )
+      .join('\n');
+  }
+  return body;
+}
+
 void runPromoteJob(jobName, async () => {
-  await createVersionsUpdatePullRequest((currentVersions) => {
+  await createVersionsUpdatePullRequest(async (currentVersions) => {
     const currentAmpVersion = getAmpVersionToCherrypick(
       ampVersion,
       currentVersions
@@ -50,10 +101,15 @@ void runPromoteJob(jobName, async () => {
       versionsChanges[channel] = `${Prefixes[channel]}${ampVersion}`;
     }
 
+    const cherryPickedPRs = await getCherryPickedPRs(
+      ampVersion,
+      Number(cherryPicksCount) - Number(currentCherryPicksCount)
+    );
+
     return {
       versionsChanges,
       title: `🌸 Promoting all ${ampVersionWithoutCherryPicksCounter}[${currentCherryPicksCount}→${cherryPicksCount}] channels`,
-      body: `Promoting release ${ampVersion} to channels: ${channels}`,
+      body: generateBody(ampVersion, channels, cherryPickedPRs),
       branch: `cherry-pick-${currentAmpVersion}-to-${ampVersion}`,
     };
   });

--- a/scripts/promote-cherry-picks.ts
+++ b/scripts/promote-cherry-picks.ts
@@ -85,6 +85,7 @@ function generateBody(
       )
       .join('\n');
   }
+  body += `\n\n[Release branch commits](https://github.com/ampproject/amphtml/commits/amp-release-${ampVersion})`;
   return body;
 }
 

--- a/scripts/promote-cherry-picks.ts
+++ b/scripts/promote-cherry-picks.ts
@@ -61,7 +61,9 @@ async function getCherryPickedPRs(
         return `* https://github.com/ampproject/amphtml/pull/${pullNumber}`;
       }
       // Ugh Octokit's typing is horrendous.
-      return (commit as unknown as components['schemas']['commit']).html_url;
+      const {html_url: htmlUrl} =
+        commit as unknown as components['schemas']['commit'];
+      return `* ${htmlUrl}`;
     });
   } catch (err) {
     console.warn('Could not fetch the list of cherry picked PRs, skipping...');


### PR DESCRIPTION
Fixes #160

Example of a PR that gets generated with this code: https://github.com/danielrozenberg/cdn-configuration/pull/42

I wrapped the new piece of code in a fail-safe try/catch so that it wouldn't fail the entire CP if anything in the API calls borks

// cc: @samouri 