### PR TITLE
Trigger npm publishing from stable, nightly, and possibly cherry-pick promote workflows

### DIFF
--- a/.github/workflows/promote-cherry-picks.yml
+++ b/.github/workflows/promote-cherry-picks.yml
@@ -26,3 +26,42 @@ jobs:
       auto-merge: ${{ github.event.inputs.auto-merge }}
     secrets:
       access-token: ${{ secrets.ACCESS_TOKEN }}
+
+  get-channels:
+    needs: promote-cherry-picks
+    runs-on: ubuntu-latest
+    outputs:
+      channels: ${{ steps.get-channels-step.outputs.channels }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Set Up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Get channels
+        id: get-channels-step
+        run: |
+          CHANNELS=$(npx ts-node ./scripts/get-channels-job.ts --amp_version="${{ github.event.inputs.amp-version }}")
+          echo "::set-output name=channels::${CHANNELS}"
+
+  npm-publish-latest:
+    if: contains(needs.get-channels.outputs.channels, 'stable')
+    needs: get-channels
+    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
+    with:
+      amp-version: ${{ github.event.inputs.amp-version }}
+      tag: 'latest'
+
+  npm-publish-nightly:
+    if: contains(needs.get-channels.outputs.channels, 'nightly')
+    needs: get-channels
+    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
+    with:
+      amp-version: ${{ github.event.inputs.amp-version }}
+      tag: 'nightly'

--- a/.github/workflows/promote-cherry-picks.yml
+++ b/.github/workflows/promote-cherry-picks.yml
@@ -51,16 +51,16 @@ jobs:
           echo "::set-output name=channels::${CHANNELS}"
 
   npm-publish-latest:
-    if: contains(needs.get-channels.outputs.channels, 'stable')
     needs: get-channels
+    if: contains(needs.get-channels.outputs.channels, 'stable')
     uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
     with:
       amp-version: ${{ github.event.inputs.amp-version }}
       tag: 'latest'
 
   npm-publish-nightly:
-    if: contains(needs.get-channels.outputs.channels, 'nightly')
     needs: get-channels
+    if: contains(needs.get-channels.outputs.channels, 'nightly')
     uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
     with:
       amp-version: ${{ github.event.inputs.amp-version }}

--- a/.github/workflows/promote-nightly.yml
+++ b/.github/workflows/promote-nightly.yml
@@ -25,3 +25,10 @@ jobs:
       auto-merge: ${{ github.event.inputs.auto-merge }}
     secrets:
       access-token: ${{ secrets.ACCESS_TOKEN }}
+
+  npm-publish-nightly:
+    needs: promote-nightly
+    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
+    with:
+      amp-version: ${{ github.event.inputs.amp-version }}
+      tag: 'nightly'

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -29,3 +29,10 @@ jobs:
       auto-merge: ${{ github.event.inputs.auto-merge }}
     secrets:
       access-token: ${{ secrets.ACCESS_TOKEN }}
+
+  npm-publish-latest:
+    needs: promote-stable
+    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
+    with:
+      amp-version: ${{ github.event.inputs.amp-version }}
+      tag: 'latest'

--- a/scripts/get-channels-job.ts
+++ b/scripts/get-channels-job.ts
@@ -1,6 +1,6 @@
 import yargs from 'yargs/yargs';
 import currentVersions from '../configs/versions.json';
-import {getChannels} from './get-channels-utils'
+import {getChannels} from './get-channels-utils';
 
 const {amp_version: ampVersion} = yargs(process.argv.slice(2))
   .options({amp_version: {type: 'string', demandOption: true}})

--- a/scripts/get-channels-job.ts
+++ b/scripts/get-channels-job.ts
@@ -1,0 +1,14 @@
+import yargs from 'yargs/yargs';
+import currentVersions from '../configs/versions.json';
+import {getChannels} from './get-channels-utils'
+
+const {amp_version: ampVersion} = yargs(process.argv.slice(2))
+  .options({amp_version: {type: 'string', demandOption: true}})
+  .parseSync();
+
+function setOutput() {
+  const channels = getChannels(ampVersion, currentVersions);
+  process.stdout.write(channels.join(', '));
+}
+
+setOutput();

--- a/scripts/get-channels-utils.ts
+++ b/scripts/get-channels-utils.ts
@@ -4,11 +4,7 @@ export function getChannels(
   ampVersion: string,
   currentVersions: Versions
 ): string[] {
-  const channels = [];
-  for (const [channel, version] of Object.entries(currentVersions)) {
-    if (version && version.slice(-13) == ampVersion) {
-      channels.push(channel);
-    }
-  }
-  return channels;
+  return Object.entries(currentVersions)
+    .filter(([, version]) => version?.slice(-13) == ampVersion)
+    .map(([channel]) => channel);
 }

--- a/scripts/get-channels-utils.ts
+++ b/scripts/get-channels-utils.ts
@@ -1,6 +1,9 @@
 import {Versions} from '../configs/schemas/versions';
 
-export function getChannels(ampVersion: string, currentVersions: Versions): string[] {
+export function getChannels(
+  ampVersion: string,
+  currentVersions: Versions
+): string[] {
   const channels = [];
   for (const [channel, version] of Object.entries(currentVersions)) {
     if (version && version.slice(-13) == ampVersion) {

--- a/scripts/get-channels-utils.ts
+++ b/scripts/get-channels-utils.ts
@@ -1,0 +1,11 @@
+import {Versions} from '../configs/schemas/versions';
+
+export function getChannels(ampVersion: string, currentVersions: Versions): string[] {
+  const channels = [];
+  for (const [channel, version] of Object.entries(currentVersions)) {
+    if (version && version.slice(-13) == ampVersion) {
+      channels.push(channel);
+    }
+  }
+  return channels;
+}

--- a/scripts/promote-cherry-picks.ts
+++ b/scripts/promote-cherry-picks.ts
@@ -5,7 +5,7 @@
 import yargs from 'yargs/yargs';
 import {Prefixes, Versions} from '../configs/schemas/versions';
 import {createVersionsUpdatePullRequest, runPromoteJob} from './promote-job';
-import {getChannels} from './get-channels-utils'
+import {getChannels} from './get-channels-utils';
 
 interface Args {
   amp_version: string;


### PR DESCRIPTION
Changes include moving `getChannels()` to its own script when promoting cherry-picks

To be merged along with https://github.com/ampproject/amphtml/pull/37757