### PR TITLE
Update QA team name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # QA approval
 # Required via branch protection rules for 1% and stable promotions
 # Not required for main
-configs/versions.json    @ampproject/amp-qa
+configs/versions.json    @ampproject/qa


### PR DESCRIPTION
We renamed `amp-qa` to `qa`. See https://github.com/ampproject/cdn-configuration/pull/177#discussion_r814296421.