### PR TITLE
Trigger npm publishing with dispatch request instead of reusing workflow

### DIFF
--- a/.github/workflows/promote-beta-experimental-opt-in.yml
+++ b/.github/workflows/promote-beta-experimental-opt-in.yml
@@ -60,22 +60,22 @@ jobs:
       shas: ${{ needs.get-missing-cherry-picks.outputs.fixes }}
 
   create-issue-on-error:
-  if: failure()
-  needs: get-missing-cherry-picks
-  permissions:
-    contents: read
-    issues: write
-  runs-on: ubuntu-latest
+    if: failure()
+    needs: get-missing-cherry-picks
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
 
-  steps:
-    - uses: actions/checkout@v2
-    - name: Create issue on error
-      uses: JasonEtco/create-an-issue@v2
-      with:
-        filename: .github/create_issue_on_error.md
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-        WORKFLOW_NAME: ${{ github.workflow }}
-        MENTION: '@ampproject/release-on-duty'
-        REPO_SLUG: ${{ github.repository }}
-        RUN_ID: ${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create issue on error
+        uses: JasonEtco/create-an-issue@v2
+        with:
+          filename: .github/create_issue_on_error.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          MENTION: '@ampproject/release-on-duty'
+          REPO_SLUG: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/promote-cherry-picks.yml
+++ b/.github/workflows/promote-cherry-picks.yml
@@ -53,15 +53,23 @@ jobs:
   npm-publish-latest:
     needs: get-channels
     if: contains(needs.get-channels.outputs.channels, 'stable')
-    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
-    with:
-      amp-version: ${{ github.event.inputs.amp-version }}
-      tag: 'latest'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger publish-npm-packages workflow on amphtml
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: 'https://api.github.com/repos/ampproject/amhtml/actions/workflows/publish-npm-packages.yml/dispatches'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "latest"}}'
+          bearerToken: ${{ secrets.ACCESS_TOKEN }}
 
   npm-publish-nightly:
     needs: get-channels
     if: contains(needs.get-channels.outputs.channels, 'nightly')
-    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
-    with:
-      amp-version: ${{ github.event.inputs.amp-version }}
-      tag: 'nightly'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger publish-npm-packages workflow on amphtml
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: 'https://api.github.com/repos/ampproject/amhtml/actions/workflows/publish-npm-packages.yml/dispatches'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "nightly"}}'
+          bearerToken: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/promote-nightly.yml
+++ b/.github/workflows/promote-nightly.yml
@@ -28,7 +28,11 @@ jobs:
 
   npm-publish-nightly:
     needs: promote-nightly
-    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
-    with:
-      amp-version: ${{ github.event.inputs.amp-version }}
-      tag: 'nightly'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send workflow dispatch event
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: 'https://api.github.com/repos/ampproject/amhtml/actions/workflows/publish-npm-packages.yml/dispatches'
+          data: '{ "ref": "main", "inputs": { "amp-version": "${{ github.event.inputs.amp-version }}", "tag": "nightly" }}'
+          bearerToken: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/promote-nightly.yml
+++ b/.github/workflows/promote-nightly.yml
@@ -30,9 +30,9 @@ jobs:
     needs: promote-nightly
     runs-on: ubuntu-latest
     steps:
-      - name: Send workflow dispatch event
+      - name: Trigger publish-npm-packages workflow on amphtml
         uses: fjogeleit/http-request-action@master
         with:
           url: 'https://api.github.com/repos/ampproject/amhtml/actions/workflows/publish-npm-packages.yml/dispatches'
-          data: '{ "ref": "main", "inputs": { "amp-version": "${{ github.event.inputs.amp-version }}", "tag": "nightly" }}'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "nightly"}}'
           bearerToken: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -32,7 +32,11 @@ jobs:
 
   npm-publish-latest:
     needs: promote-stable
-    uses: ampproject/amphtml/.github/workflows/publish-npm-packages.yml@main
-    with:
-      amp-version: ${{ github.event.inputs.amp-version }}
-      tag: 'latest'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger publish-npm-packages workflow on amphtml
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: 'https://api.github.com/repos/ampproject/amhtml/actions/workflows/publish-npm-packages.yml/dispatches'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "latest"}}'
+          bearerToken: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
This lets the workflow be run on amphtml instead of appending to our promote workflows