### PR TITLE
Add 'needs QA' label to PRs for stable and traffic promotes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+'needs QA':
+  - configs/versions.json

--- a/.github/workflows/qa-label.yml
+++ b/.github/workflows/qa-label.yml
@@ -1,0 +1,15 @@
+name: QA Label
+
+on:
+  pull_request:
+    paths:
+      - 'configs/versions.json'
+
+jobs:
+  qa-label:
+    if: startsWith(github.head_ref, 'promote-job-stable') || startsWith(github.head_ref, 'promote-job-beta-experimental-traffic')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: ${{ secrets.ACCESS_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
-# QA approval
-# Required via branch protection rules for 1% and stable promotions
-# Not required for main
-configs/versions.json    @ampproject/amp-qa
+# Assign on-duty as reviewer for version changes
+configs/versions.json    @ampproject/release-on-duty

--- a/scripts/promote-beta-experimental-traffic.ts
+++ b/scripts/promote-beta-experimental-traffic.ts
@@ -84,6 +84,7 @@ void runPromoteJob(jobName, async () => {
       title: `⏫ Promoting release ${ampVersion} to Beta/Experimental traffic channel`,
       body: `Promoting release ${ampVersion} from Beta/Experimental opt-in to traffic`,
       branch: `beta-experimental-traffic-${ampVersion}`,
+      qa: true,
     };
   });
 });

--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -76,7 +76,7 @@ export async function createVersionsUpdatePullRequest(
     branch,
     qa,
   } = await versionsMutator(currentVersions);
-  
+
   const footers = [];
   if (qa) {
     footers.push(`${qaTeam} — please approve this PR for QA`);
@@ -84,7 +84,7 @@ export async function createVersionsUpdatePullRequest(
   if (!autoMerge) {
     footers.push(`${releaseOnDuty} — please approve and merge this PR`);
   }
-  const body = `${bodyStart}\n\n${footers.join('\n')}`
+  const body = `${bodyStart}\n\n${footers.join('\n')}`;
 
   const newVersions = {
     ...currentVersions,

--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -12,6 +12,7 @@ const versionsJsonFile = 'configs/versions.json';
 const params = {owner: 'ampproject', repo: 'cdn-configuration'};
 
 const releaseOnDuty = '@ampproject/release-on-duty';
+const qaTeam = '@ampproject/amp-qa';
 
 type Awaitable<T> = T | Promise<T>; // https://github.com/microsoft/TypeScript/issues/31394
 type CreatePullRequestResponsePromise = ReturnType<
@@ -23,6 +24,7 @@ interface VersionMutatorDef {
   title: string;
   body: string;
   branch: string;
+  qa: boolean | undefined;
 }
 
 interface EnablePullRequestAutoMergeResponse {
@@ -72,11 +74,17 @@ export async function createVersionsUpdatePullRequest(
     title,
     versionsChanges,
     branch,
+    qa,
   } = await versionsMutator(currentVersions);
-
-  const body = autoMerge
-    ? `${bodyStart}\n\n// cc: ${releaseOnDuty} — FYI`
-    : `${bodyStart}\n\n${releaseOnDuty} — please approve and merge this PR`;
+  
+  const footers = [];
+  if (qa) {
+    footers.push(`${qaTeam} — please approve this PR for QA`);
+  }
+  if (!autoMerge) {
+    footers.push(`${releaseOnDuty} — please approve and merge this PR`);
+  }
+  const body = `${bodyStart}\n\n${footers.join('\n')}`
 
   const newVersions = {
     ...currentVersions,

--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -81,7 +81,9 @@ export async function createVersionsUpdatePullRequest(
   if (qa) {
     footers.push(`${qaTeam} — please approve this PR for QA`);
   }
-  if (!autoMerge) {
+  if (autoMerge) {
+    footers.push(`${releaseOnDuty} — FYI`);
+  } else {
     footers.push(`${releaseOnDuty} — please approve and merge this PR`);
   }
   const body = `${bodyStart}\n\n${footers.join('\n')}`;

--- a/scripts/promote-stable.ts
+++ b/scripts/promote-stable.ts
@@ -24,6 +24,7 @@ void runPromoteJob(jobName, async () => {
       title: `⏫ Promoting release ${ampVersion} to Stable channel`,
       body: `Promoting release ${ampVersion} from Beta/Experimental Traffic channel to Stable channel`,
       branch: `stable-${ampVersion}`,
+      qa: true,
     };
   });
 });


### PR DESCRIPTION
Changes CODEOWNERS to release-on-duty because it will automatically assign them as reviewer.

Updates the release body to cc the qa team when needed.