### PR TITLE
Output amp-version at the end of all promote jobs

### DIFF
--- a/.github/workflows/promote-reusable-workflow.yml
+++ b/.github/workflows/promote-reusable-workflow.yml
@@ -22,6 +22,10 @@ on:
         # This really should be boolean but GitHub Actions struggles with passing a boolean to a reusable workflow.
         default: 'false'
         type: string
+    outputs:
+      amp-version:
+        description: 'Promoted AMP version, which is either the given input or taken from configs/versions.json'
+        value: ${{ jobs.promote.outputs.amp-version }}
     secrets:
       access-token:
         description: 'Personal access token for the bot that will create the pull requests'
@@ -32,6 +36,8 @@ jobs:
     if: github.repository == 'ampproject/cdn-configuration'
     name: Promote ${{ inputs.channel-name }} Channel
     runs-on: ubuntu-latest
+    outputs:
+      amp-version: ${{ steps.promote-step.outputs.amp-version }}
 
     steps:
       - name: Checkout Repo
@@ -46,8 +52,12 @@ jobs:
         run: npm ci
 
       - name: ⭐ Promote ${{ inputs.channel-name }} Channel ⭐
-        run: npx ts-node scripts/${{ inputs.ts-file }} --amp_version=${{ inputs.amp-version }} --auto_merge=${{ inputs.auto-merge }}
+        id: promote-step
+        run: |
+          npx ts-node scripts/${{ inputs.ts-file }} --amp_version=${{ inputs.amp-version }} --auto_merge=${{ inputs.auto-merge }}
+          echo "::set-output name=amp-version::${{ env.AMP_VERSION }}"
         env:
+          AMP_VERSION: ${{ inputs.amp-version }}
           ACCESS_TOKEN: ${{ secrets.access-token }}
 
   create-issue-on-error:

--- a/scripts/promote-beta-experimental-opt-in.ts
+++ b/scripts/promote-beta-experimental-opt-in.ts
@@ -10,11 +10,12 @@ const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
   .options({amp_version: {type: 'string'}})
   .parseSync();
 
-void runPromoteJob(jobName, async () => {
-  await createVersionsUpdatePullRequest((currentVersions) => {
+void runPromoteJob(jobName, () => {
+  return createVersionsUpdatePullRequest((currentVersions) => {
     const ampVersion = AMP_VERSION || currentVersions.nightly.slice(2);
 
     return {
+      ampVersion,
       versionsChanges: {
         'beta-opt-in': `03${ampVersion}`,
         'experimental-opt-in': `00${ampVersion}`,

--- a/scripts/promote-beta-experimental-traffic.ts
+++ b/scripts/promote-beta-experimental-traffic.ts
@@ -67,13 +67,14 @@ function maybeRtv(experiment: ExperimentConfig, rtv: string): string | null {
 }
 
 void runPromoteJob(jobName, async () => {
-  await createVersionsUpdatePullRequest(async (currentVersions) => {
+  return createVersionsUpdatePullRequest(async (currentVersions) => {
     // We assume that the AMP version number is the same for beta-opt-in and experimental-opt-in, and only differ in their RTV prefix.
     const ampVersion = AMP_VERSION || currentVersions['beta-opt-in'].slice(2);
 
     const activeExperiments = await fetchActiveExperiments(ampVersion);
 
     return {
+      ampVersion,
       versionsChanges: {
         'beta-traffic': `03${ampVersion}`,
         'experimental-traffic': `00${ampVersion}`,

--- a/scripts/promote-cherry-picks.ts
+++ b/scripts/promote-cherry-picks.ts
@@ -87,7 +87,7 @@ function generateBody(
 }
 
 void runPromoteJob(jobName, async () => {
-  await createVersionsUpdatePullRequest(async (currentVersions) => {
+  return createVersionsUpdatePullRequest(async (currentVersions) => {
     const currentAmpVersion = getAmpVersionToCherrypick(
       ampVersion,
       currentVersions
@@ -105,6 +105,7 @@ void runPromoteJob(jobName, async () => {
     );
 
     return {
+      ampVersion,
       versionsChanges,
       title: `🌸 Promoting all ${ampVersionWithoutCherryPicksCounter}[${currentCherryPicksCount}→${cherryPicksCount}] channels`,
       body: generateBody(ampVersion, channels, cherryPickedPRs),

--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -15,11 +15,9 @@ const releaseOnDuty = '@ampproject/release-on-duty';
 const qaTeam = '@ampproject/amp-qa';
 
 type Awaitable<T> = T | Promise<T>; // https://github.com/microsoft/TypeScript/issues/31394
-type CreatePullRequestResponsePromise = ReturnType<
-  typeof octokit.createPullRequest
->;
 
 interface VersionMutatorDef {
+  ampVersion: string;
   versionsChanges: Partial<Versions>;
   title: string;
   body: string;
@@ -46,12 +44,13 @@ const {auto_merge: autoMerge} = yargs(process.argv.slice(2))
  */
 export async function runPromoteJob(
   jobName: string,
-  workflow: () => Promise<void>
+  workflow: () => Promise<string>
 ): Promise<void> {
   console.log('Running', `${jobName}...`);
   try {
-    await workflow();
+    const ampVersion = await workflow();
     console.log('Done running', `${jobName}.`);
+    process.env.AMP_VERSION = ampVersion;
   } catch (err) {
     console.error('Job', jobName, 'failed.');
     console.error('ERROR:', err);
@@ -64,12 +63,12 @@ export async function runPromoteJob(
  */
 export async function createVersionsUpdatePullRequest(
   versionsMutator: (currentVersions: Versions) => Awaitable<VersionMutatorDef>
-): CreatePullRequestResponsePromise {
+): Promise<string> {
   if (!process.env.ACCESS_TOKEN) {
     throw new Error('Environment variable ACCESS_TOKEN is missing');
   }
-
   const {
+    ampVersion,
     body: bodyStart,
     title,
     versionsChanges,
@@ -155,5 +154,5 @@ export async function createVersionsUpdatePullRequest(
     }
   }
 
-  return pullRequestResponse;
+  return ampVersion;
 }

--- a/scripts/promote-lts.ts
+++ b/scripts/promote-lts.ts
@@ -10,7 +10,7 @@ const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
   .options({amp_version: {type: 'string'}})
   .parseSync();
 
-void runPromoteJob(jobName, async () => {
+void runPromoteJob(jobName, () => {
   const dayOfMonth = new Date().getUTCDate();
   if (!AMP_VERSION && !(8 <= dayOfMonth && dayOfMonth <= 14)) {
     // Skip this job if today is not the 2nd Monday of the month. The 2nd Monday
@@ -18,13 +18,14 @@ void runPromoteJob(jobName, async () => {
     console.log(
       'Automated LTS promote only occur on the 2nd Monday of each month. Skipping...'
     );
-    return;
+    return Promise.resolve('');
   }
 
-  await createVersionsUpdatePullRequest((currentVersions) => {
+  return createVersionsUpdatePullRequest((currentVersions) => {
     const ampVersion = AMP_VERSION || currentVersions.stable.slice(2);
 
     return {
+      ampVersion,
       versionsChanges: {
         lts: `01${ampVersion}`,
       },

--- a/scripts/promote-nightly.ts
+++ b/scripts/promote-nightly.ts
@@ -6,15 +6,16 @@ import yargs from 'yargs/yargs';
 import {createVersionsUpdatePullRequest, runPromoteJob} from './promote-job';
 
 const jobName = 'promote-nightly.ts';
-const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
+const {amp_version: ampVersion} = yargs(process.argv.slice(2))
   .options({amp_version: {type: 'string', demandOption: true}})
   .parseSync();
 
-void runPromoteJob(jobName, async () => {
-  await createVersionsUpdatePullRequest(() => ({
-    versionsChanges: {nightly: `04${AMP_VERSION}`},
-    title: `⏫🌙 Promoting release ${AMP_VERSION} to Nightly channel`,
-    body: `Promoting release ${AMP_VERSION} to Nightly channel`,
-    branch: `nightly-${AMP_VERSION}`,
+void runPromoteJob(jobName, () => {
+  return createVersionsUpdatePullRequest(() => ({
+    ampVersion,
+    versionsChanges: {nightly: `04${ampVersion}`},
+    title: `⏫🌙 Promoting release ${ampVersion} to Nightly channel`,
+    body: `Promoting release ${ampVersion} to Nightly channel`,
+    branch: `nightly-${ampVersion}`,
   }));
 });

--- a/scripts/promote-stable.ts
+++ b/scripts/promote-stable.ts
@@ -10,12 +10,13 @@ const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
   .options({amp_version: {type: 'string'}})
   .parseSync();
 
-void runPromoteJob(jobName, async () => {
-  await createVersionsUpdatePullRequest((currentVersions) => {
+void runPromoteJob(jobName, () => {
+  return createVersionsUpdatePullRequest((currentVersions) => {
     // We assume that the AMP version number is the same for beta-traffic and experimental-traffic, and only differ in their RTV prefix.
     const ampVersion = AMP_VERSION || currentVersions['beta-traffic'].slice(2);
 
     return {
+      ampVersion,
       versionsChanges: {
         stable: `01${ampVersion}`,
         control: `02${ampVersion}`,


### PR DESCRIPTION
Because amp-version is an optional input, any following jobs don't always know what the amp-version is. This PR sets it as a workflow output at the end of a successful promote job.

This unblocks follow up jobs i.e. release tagger, release calendar utils.