### PR TITLE
Use promote job output for npm publishing

### DIFF
--- a/.github/workflows/promote-cherry-picks.yml
+++ b/.github/workflows/promote-cherry-picks.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@main
+        uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
           data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-cherry-picks.outputs.amp-version }}", "tag": "latest"}}'
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@main
+        uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
           data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-cherry-picks.outputs.amp-version }}", "tag": "nightly"}}'

--- a/.github/workflows/promote-cherry-picks.yml
+++ b/.github/workflows/promote-cherry-picks.yml
@@ -51,25 +51,25 @@ jobs:
           echo "::set-output name=channels::${CHANNELS}"
 
   npm-publish-latest:
-    needs: get-channels
+    needs: [get-channels, promote-cherry-picks]
     if: contains(needs.get-channels.outputs.channels, 'stable')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@master
+        uses: fjogeleit/http-request-action@main
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
-          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "latest"}}'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-cherry-picks.outputs.amp-version }}", "tag": "latest"}}'
           bearerToken: ${{ secrets.ACCESS_TOKEN }}
 
   npm-publish-nightly:
-    needs: get-channels
+    needs: [get-channels, promote-cherry-picks]
     if: contains(needs.get-channels.outputs.channels, 'nightly')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@master
+        uses: fjogeleit/http-request-action@main
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
-          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "nightly"}}'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-cherry-picks.outputs.amp-version }}", "tag": "nightly"}}'
           bearerToken: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/promote-nightly.yml
+++ b/.github/workflows/promote-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@main
+        uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
           data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-nightly.outputs.amp-version }}", "tag": "nightly"}}'

--- a/.github/workflows/promote-nightly.yml
+++ b/.github/workflows/promote-nightly.yml
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@master
+        uses: fjogeleit/http-request-action@main
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
-          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "nightly"}}'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-nightly.outputs.amp-version }}", "tag": "nightly"}}'
           bearerToken: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@master
+        uses: fjogeleit/http-request-action@main
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
-          data: '{"ref": "main", "inputs": {"amp-version": "${{ github.event.inputs.amp-version }}", "tag": "latest"}}'
+          data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-stable.outputs.amp-version }}", "tag": "latest"}}'
           bearerToken: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish-npm-packages workflow on amphtml
-        uses: fjogeleit/http-request-action@main
+        uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://api.github.com/repos/ampproject/amphtml/actions/workflows/publish-npm-packages.yml/dispatches'
           data: '{"ref": "main", "inputs": {"amp-version": "${{ needs.promote-stable.outputs.amp-version }}", "tag": "latest"}}'


### PR DESCRIPTION
Tagalong change to use `main` branch instead of `master` for a github action that switched recently!

https://github.com/fjogeleit/http-request-action/commit/35336be18d125620ff3fe6713aa63d009876c984


