### PR TITLE
Move "skip LTS" logic to the workflow level

### DIFF
--- a/.github/workflows/promote-lts.yml
+++ b/.github/workflows/promote-lts.yml
@@ -21,7 +21,19 @@ on:
         type: boolean
 
 jobs:
+  get-day:
+    runs-on: ubuntu-latest
+    outputs:
+      day: ${{ steps.day.outputs.day }}
+    steps:
+      - name: Get day of the month
+        id: day
+        run: echo "::set-output name=day::$(date +%d)"
+
   promote-lts:
+    needs: get-day
+    # The 2nd Monday always falls between the 8th to the 14th of the month (inclusive).
+    if: github.event.inputs.amp-version || (8 <= needs.get-day.outputs.day && needs.get-day.outputs.day <= 14)
     uses: ampproject/cdn-configuration/.github/workflows/promote-reusable-workflow.yml@main
     with:
       channel-name: 'LTS'

--- a/scripts/promote-lts.ts
+++ b/scripts/promote-lts.ts
@@ -11,16 +11,6 @@ const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
   .parseSync();
 
 void runPromoteJob(jobName, () => {
-  const dayOfMonth = new Date().getUTCDate();
-  if (!AMP_VERSION && !(8 <= dayOfMonth && dayOfMonth <= 14)) {
-    // Skip this job if today is not the 2nd Monday of the month. The 2nd Monday
-    // always falls between the 8th to the 14th of the month (inclusive).
-    console.log(
-      'Automated LTS promote only occur on the 2nd Monday of each month. Skipping...'
-    );
-    return Promise.resolve('');
-  }
-
   return createVersionsUpdatePullRequest((currentVersions) => {
     const ampVersion = AMP_VERSION || currentVersions.stable.slice(2);
 


### PR DESCRIPTION
Actually skip the promote-lts job, instead of resolving nothing. This will help when adding post-promote actions, i.e. calendar utils and release tagger.

