### PR TITLE
Replace `github.token` with `secrets.ACCESS_TOKEN` when creating error issues

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           filename: .github/create_issue_on_error.md
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}
           MENTION: '@ampproject/wg-infra'
           REPO_SLUG: ${{ github.repository }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           filename: .github/create_issue_on_error.md
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}
           MENTION: '@ampproject/release-on-duty'
           REPO_SLUG: ${{ github.repository }}

--- a/.github/workflows/promote-beta-experimental-opt-in.yml
+++ b/.github/workflows/promote-beta-experimental-opt-in.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           filename: .github/create_issue_on_error.md
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}
           MENTION: '@ampproject/release-on-duty'
           REPO_SLUG: ${{ github.repository }}

--- a/.github/workflows/promote-reusable-workflow.yml
+++ b/.github/workflows/promote-reusable-workflow.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           filename: .github/create_issue_on_error.md
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}
           MENTION: '@ampproject/release-on-duty'
           REPO_SLUG: ${{ github.repository }}

--- a/.github/workflows/sync-client-side-experiments-to-cdn.yml
+++ b/.github/workflows/sync-client-side-experiments-to-cdn.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           filename: .github/create_issue_on_error.md
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}
           MENTION: '@ampproject/wg-infra'
           REPO_SLUG: ${{ github.repository }}

--- a/.github/workflows/sync-versions-to-cdn.yml
+++ b/.github/workflows/sync-versions-to-cdn.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           filename: .github/create_issue_on_error.md
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}
           MENTION: '@ampproject/release-on-duty'
           REPO_SLUG: ${{ github.repository }}


### PR DESCRIPTION
Hopefully this will fix the missing tag for @—release-on-duty in those issues