### PR TITLE
Add workflow dispatch trigger to post-promote-tasks workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,11 @@
   "rules": {
     "@typescript-eslint/restrict-template-expressions": [
       2,
-      {"allowBoolean": true}
+      {
+        "allowBoolean": true,
+        "allowNullish": true,
+        "allowNumber": true
+      }
     ]
   }
 }

--- a/.github/workflows/post-promote-tasks.yml
+++ b/.github/workflows/post-promote-tasks.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get tasks
         id: get-tasks
-        run: npx ts-node ./scripts/post-promote-tasks-job.ts --pull_number="${{ github.event.pull_request.number }}" --override="${{ github.event.inputs.pull_number }}"
+        run: npx ts-node ./scripts/post-promote-tasks-job.ts --pull_number="${{ github.event.pull_request.number }}" --override_pull_number="${{ github.event.inputs.pull_number }}"
 
   npm-publish:
     needs: setup
@@ -82,7 +82,7 @@ jobs:
               "promotion":
               {
                 "releaseName": "${{ matrix.includes.amp-version }}",
-                "time": "$(${{ matrix.includes.time }}",
+                "time": "${{ matrix.includes.time }}",
                 "channel": "${{ matrix.includes.channel }}"
               }
             }

--- a/.github/workflows/post-promote-tasks.yml
+++ b/.github/workflows/post-promote-tasks.yml
@@ -8,10 +8,14 @@ on:
       - 'main'
     paths:
       - 'configs/versions.json'
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        type: number
 
 jobs:
   setup:
-    if: github.event.pull_request.merged
+    if: github.event.pull_request.merged || github.event.inputs.pull_number
     runs-on: ubuntu-latest
     outputs:
       npm: ${{ steps.get-tasks.outputs.npm }}
@@ -31,10 +35,7 @@ jobs:
 
       - name: Get tasks
         id: get-tasks
-        run: |
-          HEAD=${{ github.event.pull_request.merge_commit_sha }}
-          BASE=$(git rev-parse $HEAD^)
-          npx ts-node ./scripts/post-promote-tasks-job.ts --head="$HEAD" --base="$BASE" --title="${{ github.event.pull_request.title }}"
+        run: npx ts-node ./scripts/post-promote-tasks-job.ts --pull_number="${{ github.event.pull_request.number }}" --override="${{ github.event.inputs.pull_number }}"
 
   npm-publish:
     needs: setup
@@ -81,7 +82,7 @@ jobs:
               "promotion":
               {
                 "releaseName": "${{ matrix.includes.amp-version }}",
-                "time": "$(date +'%Y-%m-%d %H:%M:%S %Z')",
+                "time": "$(${{ matrix.includes.time }}",
                 "channel": "${{ matrix.includes.channel }}"
               }
             }
@@ -114,7 +115,7 @@ jobs:
 
   create-issue-on-error:
     if: failure()
-    needs: [setup, npm-publish, release-calendar]
+    needs: [setup, npm-publish, release-calendar, release-tagger]
     permissions:
       contents: read
       issues: write

--- a/scripts/post-promote-tasks-job.ts
+++ b/scripts/post-promote-tasks-job.ts
@@ -4,13 +4,13 @@ import {
   getVersionDiff,
   getBaseAmpVersion,
   getSha,
+  getPullRequestDetails,
 } from './post-promote-tasks-utils';
 
-const {head, base, title} = yargs(process.argv.slice(2))
+const {pull_number, override_pull_number} = yargs(process.argv.slice(2))
   .options({
-    head: {type: 'string', demandOption: true},
-    base: {type: 'string', demandOption: true},
-    title: {type: 'string', demandOption: true},
+    pull_number: {type: 'number'},
+    override_pull_number: {type: 'number'},
   })
   .parseSync();
 
@@ -44,18 +44,45 @@ const RELEASE_TAGGER: {[channel: string]: Record<string, string>} = {
     baseChannel: 'lts',
   },
 };
+interface OutputNpm {
+  'amp-version': string;
+  tag: string;
+}
+
+interface OutputCalendar {
+  'amp-version': string;
+  channel: string;
+  time: string;
+}
+
+interface OutputTagger {
+  action: string;
+  head: string;
+  base: string;
+  channel: string;
+  sha: string;
+}
 
 async function setOutput() {
+  const pullNumber = override_pull_number ? override_pull_number : pull_number;
+  if (!pullNumber) {
+    return core.setFailed(
+      `A pull request number is required. Given: pull_number: ${pull_number}; override_pull_number: ${override_pull_number}.`
+    );
+  }
+
+  const details = await getPullRequestDetails(pullNumber);
+  if (!details) {
+    return core.setFailed(
+      `Error getting merge_commit_sha and/or merged_at of PR #${pullNumber}. Check that this PR was merged.`
+    );
+  }
+
+  const {head, base, title, time} = details;
   const versionDiff = await getVersionDiff(head, base);
-  const npm: {'amp-version': string; tag: string}[] = [];
-  const calendar: {'amp-version': string; channel: string}[] = [];
-  const tagger: {
-    action: string;
-    head: string;
-    base: string;
-    channel: string;
-    sha: string;
-  }[] = [];
+  const npm: OutputNpm[] = [];
+  const calendar: OutputCalendar[] = [];
+  const tagger: OutputTagger[] = [];
 
   for (const {channel, version} of versionDiff) {
     if (PUBLISH_NPM[channel]) {
@@ -66,6 +93,7 @@ async function setOutput() {
       calendar.push({
         'amp-version': version,
         channel: RELEASE_CALENDAR[channel],
+        time,
       });
     }
 

--- a/scripts/post-promote-tasks-job.ts
+++ b/scripts/post-promote-tasks-job.ts
@@ -64,7 +64,7 @@ interface OutputTagger {
 }
 
 async function setOutput() {
-  const pullNumber = override_pull_number ? override_pull_number : pull_number;
+  const pullNumber = override_pull_number ?? pull_number;
   if (!pullNumber) {
     return core.setFailed(
       `A pull request number is required. Given: pull_number: ${pull_number}; override_pull_number: ${override_pull_number}.`

--- a/scripts/post-promote-tasks-utils.ts
+++ b/scripts/post-promote-tasks-utils.ts
@@ -10,6 +10,13 @@ interface VersionDiff {
   version: string;
 }
 
+interface PullRequestDetails {
+  head: string;
+  base: string;
+  title: string;
+  time: string;
+}
+
 async function getVersions(sha: string): Promise<IndexableVersions> {
   const response = await fetch(
     `https://raw.githubusercontent.com/ampproject/cdn-configuration/${sha}/configs/versions.json`
@@ -76,4 +83,30 @@ export async function getBaseAmpVersion(
       return baseAmpVersion;
     }
   }
+}
+
+export async function getPullRequestDetails(
+  pullNumber: number
+): Promise<PullRequestDetails | void> {
+  const octokit = new Octokit();
+  const {data: pr} = await octokit.rest.pulls.get({
+    owner: 'ampproject',
+    repo: 'cdn-configuration',
+    pull_number: pullNumber,
+  });
+
+  if (!pr.merge_commit_sha || !pr.merged_at) return;
+
+  const {data: commit} = await octokit.rest.repos.getCommit({
+    owner: 'ampproject',
+    repo: 'cdn-configuration',
+    ref: pr.merge_commit_sha,
+  });
+
+  return {
+    head: pr.merge_commit_sha,
+    base: commit.parents[0].sha,
+    title: pr.title,
+    time: pr.merged_at,
+  };
 }


### PR DESCRIPTION
This will be helpful when the workflow fails. Refactor to input just a pull request number and work from there.

Also changes release calendar time to be the PR merge time instead of the current time.