### PR TITLE
Fix QA approval check

### DIFF
--- a/scripts/check-qa-approval.ts
+++ b/scripts/check-qa-approval.ts
@@ -19,7 +19,7 @@ async function getApprovers(): Promise<string[]> {
 
   const approvers: string[] = [];
   reviews.forEach((review) => {
-    if (review.state == 'approved' && review.user) {
+    if (review.state.toUpperCase() == 'APPROVED' && review.user) {
       approvers.push(review.user.login);
     }
   });


### PR DESCRIPTION
Either the API changed `review.state` from lowercase to uppercase or I didn't pay attention 😂 
Adding `toUpperCase()` to future proof.