### PR TITLE
Update renovatebot config to consolidate dev/non-dev packages, auto-merge devs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,25 @@
 {
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "node": {
+    "supportPolicy": ["lts_latest"]
+  },
+  "commitMessagePrefix": "📦",
+  "timezone": "America/Los_Angeles",
+  "schedule": "after 12am on monday",
+  "dependencyDashboard": true,
+  "prBodyColumns": ["Package", "Update", "Type", "Change", "Package file"],
+  "packageRules": [
+    {
+      "groupName": "devDependencies",
+      "matchFiles": ["package.json"],
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "groupName": "dependencies",
+      "matchFiles": ["package.json"],
+      "matchDepTypes": ["dependencies"],
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
Similar to `cdn-worker`'s renovate.json