### PR TITLE
Use octokit's type def versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "devDependencies": {
         "@actions/core": "1.9.0",
-        "@octokit/openapi-types": "12.5.0",
         "@octokit/rest": "18.12.0",
         "@types/mocha": "9.1.1",
         "@types/node": "16.11.41",
@@ -271,12 +270,6 @@
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.5.0.tgz",
-      "integrity": "sha512-VatvE5wtRkJq6hAWGTBZ62WkrdlCiy0G0u27cVOYTfAWVZi7QqTurVcjpsyc5+9hXLPRP5O/DaNEs4TgAp4Mqg==",
-      "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "2.17.0",
@@ -3351,12 +3344,6 @@
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
-    },
-    "@octokit/openapi-types": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.5.0.tgz",
-      "integrity": "sha512-VatvE5wtRkJq6hAWGTBZ62WkrdlCiy0G0u27cVOYTfAWVZi7QqTurVcjpsyc5+9hXLPRP5O/DaNEs4TgAp4Mqg==",
-      "dev": true
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "devDependencies": {
     "@actions/core": "1.9.0",
-    "@octokit/openapi-types": "12.5.0",
     "@octokit/rest": "18.12.0",
     "@types/mocha": "9.1.1",
     "@types/node": "16.11.41",

--- a/scripts/get-missing-cherry-picks-utils.ts
+++ b/scripts/get-missing-cherry-picks-utils.ts
@@ -1,7 +1,10 @@
 import {Octokit} from '@octokit/rest';
-import {components} from '@octokit/openapi-types';
+import {GetResponseTypeFromEndpointMethod} from '@octokit/types';
 
-type Commit = components['schemas']['commit'];
+type Commits = GetResponseTypeFromEndpointMethod<
+  Octokit['repos']['compareCommitsWithBasehead']
+>['data']['commits'];
+
 const params = {owner: 'ampproject', repo: 'amphtml'};
 
 export async function getMissingCommits(
@@ -39,13 +42,14 @@ export async function getMissingCommits(
 async function getCherryPickCommits(
   octokit: Octokit,
   release: string
-): Promise<Commit[] | undefined> {
+): Promise<Commits | undefined> {
   if (release.endsWith('000')) return;
   const base = release.slice(0, -3) + '000';
   const response = await octokit.rest.repos.compareCommitsWithBasehead({
     ...params,
     basehead: `${base}...${release}`,
   });
+
   return response.data.commits;
 }
 

--- a/scripts/promote-cherry-picks.ts
+++ b/scripts/promote-cherry-picks.ts
@@ -10,7 +10,6 @@ import {
   runPromoteJob,
 } from './promote-job';
 import {getChannels} from './get-channels-utils';
-import {components} from '@octokit/openapi-types';
 
 interface Args {
   amp_version: string;
@@ -60,10 +59,8 @@ async function getCherryPickedPRs(
       if (pullNumber) {
         return `* https://github.com/ampproject/amphtml/pull/${pullNumber}`;
       }
-      // Ugh Octokit's typing is horrendous.
-      const {html_url: htmlUrl} =
-        commit as unknown as components['schemas']['commit'];
-      return `* ${htmlUrl}`;
+
+      return `* ${commit.url}`;
     });
   } catch (err) {
     console.warn('Could not fetch the list of cherry picked PRs, skipping...');


### PR DESCRIPTION
Use octokit's type def versions instead of installing it separately, to avoid version mismatches.

closes #422, closes #429