### PR TITLE
Fix release freeze logic

### DIFF
--- a/.github/workflows/promote-lts.yml
+++ b/.github/workflows/promote-lts.yml
@@ -40,5 +40,6 @@ jobs:
       ts-file: 'promote-lts.ts'
       amp-version: ${{ github.event.inputs.amp-version }}
       auto-merge: ${{ github.event.inputs.auto-merge }}
+      check-freeze: true
     secrets:
       access-token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/promote-reusable-workflow.yml
+++ b/.github/workflows/promote-reusable-workflow.yml
@@ -22,6 +22,11 @@ on:
         # This really should be boolean but GitHub Actions struggles with passing a boolean to a reusable workflow.
         default: 'false'
         type: string
+      check-freeze:
+        description: 'Skip promote during release freezes. This should be set to true for Stable and LTS channels, with the exception of P0 cherry-picks'
+        required: false
+        default: false
+        type: boolean
     secrets:
       access-token:
         description: 'Personal access token for the bot that will create the pull requests'
@@ -45,7 +50,13 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Check for a release freeze
+        id: check-freeze
+        if: ${{ inputs.check-freeze }}
+        run: npx ts-node scripts/check-release-freeze.ts
+
       - name: ⭐ Promote ${{ inputs.channel-name }} Channel ⭐
+        if: ${{ !inputs.check-freeze || !steps.check-freeze.outputs.freeze }}
         run: npx ts-node scripts/${{ inputs.ts-file }} --amp_version=${{ inputs.amp-version }} --auto_merge=${{ inputs.auto-merge }}
         env:
           ACCESS_TOKEN: ${{ secrets.access-token }}

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -27,5 +27,6 @@ jobs:
       ts-file: 'promote-stable.ts'
       amp-version: ${{ github.event.inputs.amp-version }}
       auto-merge: ${{ github.event.inputs.auto-merge }}
+      check-freeze: true
     secrets:
       access-token: ${{ secrets.ACCESS_TOKEN }}

--- a/scripts/check-release-freeze.ts
+++ b/scripts/check-release-freeze.ts
@@ -10,15 +10,17 @@ function main() {
     const end = new Date(freezedate.end);
 
     if (start <= today && today <= end) {
-      core.info(`There is a release freeze in effect today.`)
-      core.info(`Date range: ${start.toLocaleDateString()} to ${end.toLocaleDateString()}`)
-      core.info(`Description: ${freezedate.description}`)
+      core.info(`There is a release freeze in effect today.`);
+      core.info(
+        `Date range: ${start.toLocaleDateString()} to ${end.toLocaleDateString()}`
+      );
+      core.info(`Description: ${freezedate.description}`);
       freeze = true;
       break;
     }
   }
 
- core.setOutput('freeze', freeze);
+  core.setOutput('freeze', freeze);
 }
 
 main();

--- a/scripts/check-release-freeze.ts
+++ b/scripts/check-release-freeze.ts
@@ -1,0 +1,24 @@
+import * as core from '@actions/core';
+import freezedatesJson from '../configs/freezedates.json';
+
+function main() {
+  let freeze = false;
+  const today = new Date(Date.now());
+
+  for (const freezedate of freezedatesJson.freezedates) {
+    const start = new Date(freezedate.start);
+    const end = new Date(freezedate.end);
+
+    if (start <= today && today <= end) {
+      core.info(`There is a release freeze in effect today.`)
+      core.info(`Date range: ${start.toLocaleDateString()} to ${end.toLocaleDateString()}`)
+      core.info(`Description: ${freezedate.description}`)
+      freeze = true;
+      break;
+    }
+  }
+
+ core.setOutput('freeze', freeze);
+}
+
+main();

--- a/test/check-file-changes.ts
+++ b/test/check-file-changes.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import yargs from 'yargs/yargs';
-import freezedatesJson from '../configs/freezedates.json';
 
 const {diff} = yargs(process.argv.slice(2))
   .options({diff: {type: 'string', demandOption: true}})
@@ -17,33 +16,6 @@ describe('check file changes', () => {
       `Only 1 config change allowed at a time. Found ${
         changes.length
       }: ${changes.join(', ')}`
-    );
-  });
-
-  it('should not change `versions.json` during a freeze', () => {
-    const change = files.some((file) => file.includes('configs/versions.json'));
-
-    if (!change) {
-      return;
-    }
-
-    let currentFreeze = null;
-    const today = new Date(Date.now());
-
-    for (const freezedate of freezedatesJson.freezedates) {
-      const start = new Date(freezedate.start);
-      const end = new Date(freezedate.end);
-
-      if (start <= today && today <= end) {
-        currentFreeze = freezedate;
-        break;
-      }
-    }
-
-    assert.ok(
-      !currentFreeze,
-      '`versions.json` cannot be changed during a release freeze: ' +
-        JSON.stringify(currentFreeze)
     );
   });
 });


### PR DESCRIPTION
fix: only freeze for stable and lts, [as per docs](https://amp.dev/documentation/guides-and-tutorials/learn/spec/release-schedule/)

fix: allow cherry-picks during freezes instead of a ban on all changes to `configs/versions.json`

improvement: check for release freeze before creating a PR, instead of at the PR check level. This makes more sense for on-duty and avoids unnecessary PRs from being made
