### PR TITLE
Check forward promote

### DIFF
--- a/scripts/promote-beta-experimental-opt-in.ts
+++ b/scripts/promote-beta-experimental-opt-in.ts
@@ -5,7 +5,7 @@
 import yargs from 'yargs/yargs';
 import {
   createVersionsUpdatePullRequest,
-  isForwardPromote,
+  ensureForwardPromote,
   runPromoteJob,
 } from './promote-job';
 
@@ -20,18 +20,12 @@ void runPromoteJob(jobName, () => {
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {
-      if (
-        !isForwardPromote(ampVersion, [
-          currentVersions['beta-opt-in'],
-          currentVersions['beta-traffic'],
-          currentVersions.stable,
-          currentVersions.lts,
-        ])
-      ) {
-        throw new Error(
-          'The scheduled promotion is older than current versions. This is most likely due to a stale nightly branch.'
-        );
-      }
+      ensureForwardPromote(ampVersion, [
+        currentVersions['beta-opt-in'],
+        currentVersions['beta-traffic'],
+        currentVersions.stable,
+        currentVersions.lts,
+      ]);
     }
 
     return {

--- a/scripts/promote-beta-experimental-opt-in.ts
+++ b/scripts/promote-beta-experimental-opt-in.ts
@@ -3,7 +3,11 @@
  */
 
 import yargs from 'yargs/yargs';
-import {createVersionsUpdatePullRequest, runPromoteJob} from './promote-job';
+import {
+  createVersionsUpdatePullRequest,
+  isForwardPromote,
+  runPromoteJob,
+} from './promote-job';
 
 const jobName = 'promote-beta-experimental-opt-in.ts';
 const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
@@ -13,6 +17,22 @@ const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
 void runPromoteJob(jobName, () => {
   return createVersionsUpdatePullRequest((currentVersions) => {
     const ampVersion = AMP_VERSION || currentVersions.nightly.slice(2);
+
+    // for scheduled promotions, check that the new version is a forward promote
+    if (!AMP_VERSION) {
+      if (
+        !isForwardPromote(ampVersion, [
+          currentVersions['beta-opt-in'],
+          currentVersions['beta-traffic'],
+          currentVersions.stable,
+          currentVersions.lts,
+        ])
+      ) {
+        throw new Error(
+          'The scheduled promotion is older than current versions. This is most likely due to a stale nightly branch.'
+        );
+      }
+    }
 
     return {
       ampVersion,

--- a/scripts/promote-beta-experimental-traffic.ts
+++ b/scripts/promote-beta-experimental-traffic.ts
@@ -5,7 +5,7 @@
 import yargs from 'yargs/yargs';
 import {
   createVersionsUpdatePullRequest,
-  isForwardPromote,
+  ensureForwardPromote,
   octokit,
   runPromoteJob,
 } from './promote-job';
@@ -74,17 +74,11 @@ void runPromoteJob(jobName, async () => {
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {
-      if (
-        !isForwardPromote(ampVersion, [
-          currentVersions['beta-traffic'],
-          currentVersions.stable,
-          currentVersions.lts,
-        ])
-      ) {
-        throw new Error(
-          'The scheduled promotion is older than current versions. This is most likely due to a stale nightly branch.'
-        );
-      }
+      ensureForwardPromote(ampVersion, [
+        currentVersions['beta-traffic'],
+        currentVersions.stable,
+        currentVersions.lts,
+      ]);
     }
 
     const activeExperiments = await fetchActiveExperiments(ampVersion);

--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -169,15 +169,16 @@ export async function createVersionsUpdatePullRequest(
   return ampVersion;
 }
 
-export function isForwardPromote(
+export function ensureForwardPromote(
   newVersion: string,
   currentRtvs: string[]
-): boolean {
+): void {
   for (const rtv of currentRtvs) {
     if (rtv.slice(-13) >= newVersion) {
-      return false;
+      core.notice('Skipping job');
+      throw new Error(
+        'The scheduled promotion is older than current versions. This is most likely due to a lack of new commits on the nightly branch. No action is needed.'
+      );
     }
   }
-
-  return true;
 }

--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -45,7 +45,7 @@ const {auto_merge: autoMerge} = yargs(process.argv.slice(2))
  */
 export async function runPromoteJob(
   jobName: string,
-  workflow: () => Promise<string>
+  workflow: () => Promise<string | undefined>
 ): Promise<void> {
   console.log('Running', `${jobName}...`);
   try {
@@ -167,4 +167,17 @@ export async function createVersionsUpdatePullRequest(
   }
 
   return ampVersion;
+}
+
+export function isForwardPromote(
+  newVersion: string,
+  currentRtvs: string[]
+): boolean {
+  for (const rtv of currentRtvs) {
+    if (rtv.slice(-13) >= newVersion) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/scripts/promote-lts.ts
+++ b/scripts/promote-lts.ts
@@ -5,7 +5,7 @@
 import yargs from 'yargs/yargs';
 import {
   createVersionsUpdatePullRequest,
-  isForwardPromote,
+  ensureForwardPromote,
   runPromoteJob,
 } from './promote-job';
 
@@ -20,11 +20,7 @@ void runPromoteJob(jobName, () => {
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {
-      if (!isForwardPromote(ampVersion, [currentVersions.lts])) {
-        throw new Error(
-          'The scheduled promotion is older than current versions. This is most likely due to a stale nightly branch.'
-        );
-      }
+      ensureForwardPromote(ampVersion, [currentVersions.lts]);
     }
 
     return {

--- a/scripts/promote-stable.ts
+++ b/scripts/promote-stable.ts
@@ -3,7 +3,11 @@
  */
 
 import yargs from 'yargs/yargs';
-import {createVersionsUpdatePullRequest, runPromoteJob} from './promote-job';
+import {
+  createVersionsUpdatePullRequest,
+  isForwardPromote,
+  runPromoteJob,
+} from './promote-job';
 
 const jobName = 'promote-stable.ts';
 const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
@@ -14,6 +18,20 @@ void runPromoteJob(jobName, () => {
   return createVersionsUpdatePullRequest((currentVersions) => {
     // We assume that the AMP version number is the same for beta-traffic and experimental-traffic, and only differ in their RTV prefix.
     const ampVersion = AMP_VERSION || currentVersions['beta-traffic'].slice(2);
+
+    // for scheduled promotions, check that the new version is a forward promote
+    if (!AMP_VERSION) {
+      if (
+        !isForwardPromote(ampVersion, [
+          currentVersions.stable,
+          currentVersions.lts,
+        ])
+      ) {
+        throw new Error(
+          'The scheduled promotion is older than current versions. This is most likely due to a stale nightly branch.'
+        );
+      }
+    }
 
     return {
       ampVersion,

--- a/scripts/promote-stable.ts
+++ b/scripts/promote-stable.ts
@@ -5,7 +5,7 @@
 import yargs from 'yargs/yargs';
 import {
   createVersionsUpdatePullRequest,
-  isForwardPromote,
+  ensureForwardPromote,
   runPromoteJob,
 } from './promote-job';
 
@@ -21,16 +21,10 @@ void runPromoteJob(jobName, () => {
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {
-      if (
-        !isForwardPromote(ampVersion, [
-          currentVersions.stable,
-          currentVersions.lts,
-        ])
-      ) {
-        throw new Error(
-          'The scheduled promotion is older than current versions. This is most likely due to a stale nightly branch.'
-        );
-      }
+      ensureForwardPromote(ampVersion, [
+        currentVersions.stable,
+        currentVersions.lts,
+      ]);
     }
 
     return {


### PR DESCRIPTION
With nightlies slowing down, the scheduled jobs could potentially try to promote an old or existing version. For example, the beta-opt-in promote job https://github.com/ampproject/cdn-configuration/pull/445 tried to promote `2207071723000` when it was already in stable.

This PR checks that each scheduled promote is a newer version, unless manually entered for reverting.