### PR TITLE
Pause `attribution-reporting` experiment

### DIFF
--- a/configs/client-side-experiments.json
+++ b/configs/client-side-experiments.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "attribution-reporting",
-      "percentage": 0.01
+      "percentage": 0
     }
   ]
 }


### PR DESCRIPTION
False start. Apparently we used the wrong ids, pausing until amp change is implemented and rolls out.

Partial https://github.com/ampproject/amphtml/issues/35347