### PR TITLE
Ramp up `attribution-reporting` experiment to 4%

### DIFF
--- a/configs/client-side-experiments.json
+++ b/configs/client-side-experiments.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "attribution-reporting",
-      "percentage": 0.01
+      "percentage": 0.04
     }
   ]
 }


### PR DESCRIPTION
Initial metrics are a bit lossy on impressions (~1%) but because eligibility is gated on browser experiment status it is a small sample. Ramp to get more data.

https://experiments.corp.google.com/#/portal/study/contentads::5618652/analysis?label=_:L5ovJ8u3x06eVhapokb49bpG2Ps

https://github.com/ampproject/amphtml/issues/35347