### PR TITLE
Don't throw an error when no promotion is required

### DIFF
--- a/scripts/promote-job.ts
+++ b/scripts/promote-job.ts
@@ -179,10 +179,10 @@ export function ensureForwardPromote(
 ): void {
   for (const rtv of currentRtvs) {
     if (rtv.slice(-13) >= newVersion) {
-      core.notice('Skipping job');
-      throw new Error(
-        'The scheduled promotion is older than current versions. This is most likely due to a lack of new commits on the nightly branch. No action is needed.'
+      core.notice(
+        'The scheduled promotion is older than current versions. No action is needed.'
       );
+      process.exit(0);
     }
   }
 }


### PR DESCRIPTION
This is happening more and more often, there's no reason to create an error issue for these anymore :)