### PR TITLE
Fix `labeler.yml` to match new v5 syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,5 @@
 'needs QA':
-  - configs/versions.json
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - configs/versions.json


### PR DESCRIPTION
Renovatebot's PR #1068 updated this action to v5, and the current config file is [incompatible](https://github.com/ampproject/cdn-configuration/actions/runs/7549941851/job/20554785118#step:2:9). This PR should fix it