### PR TITLE
Fix for broken releases

### DIFF
--- a/scripts/get-missing-cherry-picks-job.ts
+++ b/scripts/get-missing-cherry-picks-job.ts
@@ -5,11 +5,11 @@ import {getMissingCommits} from './get-missing-cherry-picks-utils';
 import * as core from '@actions/core';
 
 const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
-  .options({amp_version: {type: 'string'}})
+  .options({amp_version: {type: 'string', default: ''}})
   .parseSync();
 
 async function setOutput() {
-  const ampVersion = AMP_VERSION ?? currentVersions.nightly.slice(2);
+  const ampVersion = AMP_VERSION || currentVersions.nightly.slice(2);
 
   const releases = new Set(
     [

--- a/scripts/promote-beta-experimental-opt-in.ts
+++ b/scripts/promote-beta-experimental-opt-in.ts
@@ -11,12 +11,12 @@ import {
 
 const jobName = 'promote-beta-experimental-opt-in.ts';
 const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
-  .options({amp_version: {type: 'string'}})
+  .options({amp_version: {type: 'string', default: ''}})
   .parseSync();
 
 void runPromoteJob(jobName, () => {
   return createVersionsUpdatePullRequest((currentVersions) => {
-    const ampVersion = AMP_VERSION ?? currentVersions.nightly.slice(2);
+    const ampVersion = AMP_VERSION || currentVersions.nightly.slice(2);
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {

--- a/scripts/promote-beta-experimental-traffic.ts
+++ b/scripts/promote-beta-experimental-traffic.ts
@@ -24,7 +24,7 @@ interface ExperimentsConfig {
 
 const jobName = 'promote-beta-experimental-traffic.ts';
 const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
-  .options({amp_version: {type: 'string'}})
+  .options({amp_version: {type: 'string', default: ''}})
   .parseSync();
 
 async function fetchActiveExperiments(
@@ -70,7 +70,7 @@ function maybeRtv(experiment: ExperimentConfig, rtv: string): string | null {
 void runPromoteJob(jobName, async () => {
   return createVersionsUpdatePullRequest(async (currentVersions) => {
     // We assume that the AMP version number is the same for beta-opt-in and experimental-opt-in, and only differ in their RTV prefix.
-    const ampVersion = AMP_VERSION ?? currentVersions['beta-opt-in'].slice(2);
+    const ampVersion = AMP_VERSION || currentVersions['beta-opt-in'].slice(2);
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {

--- a/scripts/promote-lts.ts
+++ b/scripts/promote-lts.ts
@@ -11,12 +11,12 @@ import {
 
 const jobName = 'promote-lts.ts';
 const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
-  .options({amp_version: {type: 'string'}})
+  .options({amp_version: {type: 'string', default: ''}})
   .parseSync();
 
 void runPromoteJob(jobName, () => {
   return createVersionsUpdatePullRequest((currentVersions) => {
-    const ampVersion = AMP_VERSION ?? currentVersions.stable.slice(2);
+    const ampVersion = AMP_VERSION || currentVersions.stable.slice(2);
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {

--- a/scripts/promote-stable.ts
+++ b/scripts/promote-stable.ts
@@ -11,13 +11,13 @@ import {
 
 const jobName = 'promote-stable.ts';
 const {amp_version: AMP_VERSION} = yargs(process.argv.slice(2))
-  .options({amp_version: {type: 'string'}})
+  .options({amp_version: {type: 'string', default: ''}})
   .parseSync();
 
 void runPromoteJob(jobName, () => {
   return createVersionsUpdatePullRequest((currentVersions) => {
     // We assume that the AMP version number is the same for beta-traffic and experimental-traffic, and only differ in their RTV prefix.
-    const ampVersion = AMP_VERSION ?? currentVersions['beta-traffic'].slice(2);
+    const ampVersion = AMP_VERSION || currentVersions['beta-traffic'].slice(2);
 
     // for scheduled promotions, check that the new version is a forward promote
     if (!AMP_VERSION) {


### PR DESCRIPTION
Looks like I broke the releases a few months back (!) with #1293, specifically with this seemingly innocent change!

https://github.com/ampproject/cdn-configuration/commit/7e9d281f11c730870022495a031f61ef4f801588?diff=split&w=0#diff-c8619a8b92cdac8faa7198af88243308b7da658b5f509d74931454428c3de950

The const `AMP_VERSION` is of type `String | undefined`. Before the change, both possible values of `undefined` or `''` (empty string) would be evaluated as false for the purpose of `||` and the fallback value was used.

After the change, only `undefined` was evaluated as false for the purpose of `??`, but since we always pass an `--amp_version` flag, even if it's an empty string, it means that the fallback value was never used

This PR fixes this by explicitly setting a default value for the flag to be an empty string (so the type of `AMP_VERSION` is now `String` instead of `String | undefined`), and reverting to using `||` instead of `??`.